### PR TITLE
Update install instructions with correct repo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,13 +6,13 @@ In this series, we'll show you how to build a professionally designed, custom we
 
 Here is a step-by-step guide for how to use this repo:
 
-1. Clone this repo using `git clone --depth=1 https://github.com/payloadcms/nextjs-custom-server.git <YOUR_PROJECT_NAME>`
-1. Run `cp .env.example .env` to create an `.env` file
-1. Fill out your `.env` file with values that describe your environment
-1. Run `yarn` or `npm install`
-1. Run `yarn dev` to open a development environment
-1. *optional* Run `yarn seed` to add sample pages and a Media upload
-1. Go to [http://localhost:3000/admin](http://localhost:3000/admin) to create your first user
+1. Clone this repo using `git clone --depth=1 https://github.com/payloadcms/custom-website-series.git <YOUR_PROJECT_NAME>`
+3. Run `cp .env.example .env` to create an `.env` file
+4. Fill out your `.env` file with values that describe your environment
+5. Run `yarn` or `npm install`
+6. Run `yarn dev` to open a development environment
+7. *optional* Run `yarn seed` to add sample pages and a Media upload
+8. Go to [http://localhost:3000/admin](http://localhost:3000/admin) to create your first user
 
 ## Building and serving in Production
 


### PR DESCRIPTION
The install instructions referenced the nextjs-custom-server repo and I think this should be the custom-website-series repo? I followed the instructions and didn't use the git clone button at the top of the repo and so ended up with the wrong install!

I assume the rest of the install instructions after the git clone step are still correct.